### PR TITLE
Changed inspect.getargspec to inspect.getfullargspec since it was depreciated in Python 3.11

### DIFF
--- a/histlite/__init__.py
+++ b/histlite/__init__.py
@@ -1684,10 +1684,10 @@ def hist_from_eval(f, vectorize=True, err_f=None, ndim=None, **kwargs):
     """
     # infer number of arguments
     try:
-        spec = inspect.getargspec(f)
+        spec = inspect.getfullargspec(f)
         ismethod = inspect.ismethod(f)
     except:
-        spec = inspect.getargspec(f.__call__)
+        spec = inspect.getfullargspec(f.__call__)
         ismethod = inspect.ismethod(f.__call__)
     if ndim is None:
         ndim = len(spec.args) - len(spec.defaults or [])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # histlite/setup.py
 
 from setuptools import setup, find_packages
+import os
 import sys
 import setuptools
 


### PR DESCRIPTION
With Python 3.11 inspect.getargspec is now fully depreciated. Simply changing it to inspect.getfullargspec fully solves the problem. Also: setup.py needs to import os to enable installation with pip from github.